### PR TITLE
Make dependency on 'num' optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
 script:
-    - cargo build --verbose
+    - cargo build --features "num" --verbose
     - cargo test --verbose
     - cargo doc --no-deps --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0/MIT"
 [dependencies]
 
 log = "^0.3"
-num = "^0.1"
 rand = "^0.3"
 rustc-serialize = "^0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0/MIT"
 [dependencies]
 
 log = "^0.3"
+num = { version="^0.1", optional=true }
 rand = "^0.3"
 rustc-serialize = "^0.3"
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -7,25 +7,131 @@
 // except according to those terms.
 //
 
+use rand;
+use rand::Rng;
+
+use std::hash::Hash;
+use std::fmt::Debug;
 use std::str::FromStr;
 use std::net;
 
-use num;
 use rustc_serialize as serialize;
+use rustc_serialize::hex::ToHex;
+use rustc_serialize::hex::FromHex;
 
+/// Generalization of num::BigUint, with hexadecimal encoding and decoding
+pub trait GenericId : Hash + PartialEq + Eq + Ord + Clone + Send + Sync + Debug {
+    fn bitxor(&self, other: &Self) -> Self;
+    fn is_zero(&self) -> bool;
+    fn bits(&self) -> usize;
+    /// num::bigint::RandBigInt::gen_biguint
+    fn gen(bit_size: usize) -> Self;
+
+    fn encode<S:serialize::Encoder> (&self, s: &mut S) -> Result<(), S::Error>;
+    fn decode<D:serialize::Decoder> (d : &mut D) -> Result<Self, D::Error>;
+}
+
+impl GenericId for u64 {
+    fn bitxor(&self, other: &u64) -> u64 {
+        self ^ other
+    }
+    fn is_zero(&self) -> bool {
+        *self == 0
+    }
+    fn bits(&self) -> usize {
+        (64 - self.leading_zeros()) as usize
+    }
+    fn gen(bit_size: usize) -> u64 {
+        assert!(bit_size <= 64);
+        if bit_size == 64 {
+            rand::thread_rng().next_u64()
+        }
+        else {
+            rand::thread_rng().gen_range(0, 1 << bit_size)
+        }
+    }
+
+    fn encode<S:serialize::Encoder> (&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_str(&format!("{:x}", self))
+    }
+    fn decode<D:serialize::Decoder> (d : &mut D) -> Result<u64, D::Error> {
+        let s: &str = &try!(d.read_str());
+        match u64::from_str_radix(s, 16) {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                let err = format!("Expected hex-encoded ID, got {}, error {:?}", s, e);
+                Err(d.error(&err))
+            }
+        }
+    }
+}
+
+impl GenericId for Vec<u8> {
+    fn bitxor(&self, other: &Vec<u8>) -> Vec<u8> {
+        self.iter().zip(other.iter()).map(|(digit1, digit2)| digit1 ^ digit2).collect()
+    }
+    fn is_zero(&self) -> bool {
+        self.iter().all(|digit| *digit == 0)
+    }
+    fn bits(&self) -> usize {
+        let mut bits = self.len()*8;
+        for digit in self {
+            if *digit == 0 {
+                bits -= 8;
+            }
+            else {
+                return bits - digit.leading_zeros() as usize
+            }
+        }
+        assert!(bits == 0);
+        0
+    }
+    fn gen(bit_size: usize) -> Vec<u8> {
+        let nb_full_digits = bit_size/8;
+        let nb_bits_partial_digit = bit_size%8;
+        let mut rng = rand::thread_rng();
+        if nb_bits_partial_digit == 0 {
+            let mut res = vec![0u8; nb_full_digits];
+            rng.fill_bytes(&mut res);
+            res
+        }
+        else {
+            let mut res = vec![0u8; nb_full_digits+1];
+            let first_digit = rng.gen_range(0, 1<<(nb_bits_partial_digit-1));
+            res[0] = first_digit;
+            rng.fill_bytes(&mut res[1..nb_full_digits+1]);
+            res
+        }
+    }
+
+    fn encode<S:serialize::Encoder> (&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_str(&self.to_hex())
+    }
+    fn decode<D:serialize::Decoder> (d : &mut D) -> Result<Vec<u8>, D::Error> {
+        let s = try!(d.read_str());
+        match s.from_hex() {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                let err = format!("Expected hex-encoded ID, got {}, error {:?}", s, e);
+                Err(d.error(&err))
+            }
+        }
+    }
+}
 
 /// Trait representing table with known nodes.
 ///
 /// Keeps some reasonable subset of known nodes passed to `update`.
-pub trait GenericNodeTable : Send + Sync {
+pub trait GenericNodeTable<TId> : Send + Sync
+        where TId: GenericId {
     /// Generate suitable random ID.
-    fn random_id(&self) -> num::BigUint;
+    fn random_id(&self) -> TId;
     /// Store or update node in the table.
-    fn update(&mut self, node: &Node) -> bool;
+    fn update(&mut self, node: &Node<TId>) -> bool;
     /// Find given number of node, closest to given ID.
-    fn find(&self, id: &num::BigUint, count: usize) -> Vec<Node>;
+    fn find(&self, id: &TId, count: usize) -> Vec<Node<TId>>;
     /// Pop expired or the oldest nodes from table for inspection.
-    fn pop_oldest(&mut self) -> Vec<Node>;
+    fn pop_oldest(&mut self) -> Vec<Node<TId>>;
 }
 
 /// Structure representing a node in system.
@@ -33,34 +139,36 @@ pub trait GenericNodeTable : Send + Sync {
 /// Every node has an address (IP and port) and a numeric ID, which is
 /// used to calculate metrics and look up data.
 #[derive(Clone, Debug)]
-pub struct Node {
+pub struct Node<TId> {
     /// Network address of the node.
     pub address: net::SocketAddr,
     /// ID of the node.
-    pub id: num::BigUint
+    pub id: TId
 }
 
 /// Trait representing the API.
-pub trait GenericAPI {
+pub trait GenericAPI<TId>
+        where TId: GenericId {
     /// Value type.
     type TValue: Send + Sync + Clone;
     /// Ping a node.
-    fn ping<F>(&mut self, node: &Node, callback: F)
-        where F: FnOnce(&Node, bool);
+    fn ping<F>(&mut self, node: &Node<TId>, callback: F)
+        where F: FnOnce(&Node<TId>, bool);
     /// Return nodes clothest to the given id.
-    fn find_node<F>(&mut self, id: &num::BigUint, callback: F)
-        where F: FnOnce(Vec<Node>);
+    fn find_node<F>(&mut self, id: &TId, callback: F)
+        where F: FnOnce(Vec<Node<TId>>);
     /// Find a value in the network.
     ///
     /// Either returns a value or several clothest nodes.
-    fn find_value<F>(&mut self, id: &num::BigUint, callback: F)
-        where F: FnOnce(Option<Self::TValue>, Vec<Node>);
+    fn find_value<F>(&mut self, id: &TId, callback: F)
+        where F: FnOnce(Option<Self::TValue>, Vec<Node<TId>>);
     /// Store a value on a node.
-    fn store(&mut self, node: &Node, id: &num::BigUint, value: Self::TValue);
+    fn store(&mut self, node: &Node<TId>, id: &TId, value: Self::TValue);
 }
 
 
-impl serialize::Encodable for Node {
+impl<TId> serialize::Encodable for Node<TId>
+        where TId: GenericId {
     fn encode<S:serialize::Encoder> (&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_struct("Node", 2, |s| {
             try!(s.emit_struct_field("address", 0, |s2| {
@@ -68,18 +176,16 @@ impl serialize::Encodable for Node {
                 addr.encode(s2)
             }));
 
-            try!(s.emit_struct_field("id", 1, |s2| {
-                let id = format!("{}", self.id);
-                id.encode(s2)
-            }));
+            try!(s.emit_struct_field("id", 1, |s2| self.id.encode(s2)));
 
             Ok(())
         })
     }
 }
 
-impl serialize::Decodable for Node {
-    fn decode<D:serialize::Decoder> (d : &mut D) -> Result<Node, D::Error> {
+impl<TId> serialize::Decodable for Node<TId>
+        where TId: GenericId {
+    fn decode<D:serialize::Decoder> (d : &mut D) -> Result<Node<TId>, D::Error> {
         d.read_struct("Node", 2, |d| {
             let addr = try!(d.read_struct_field("address", 0, |d2| {
                 let s = try!(d2.read_str());
@@ -92,16 +198,7 @@ impl serialize::Decodable for Node {
                 }
             }));
 
-            let id = try!(d.read_struct_field("id", 1, |d2| {
-                let s = try!(d2.read_str());
-                match FromStr::from_str(&s) {
-                    Ok(id) => Ok(id),
-                    Err(e) => {
-                        let err = format!("Expected ID, got {}, error {:?}", s, e);
-                        Err(d2.error(&err))
-                    }
-                }
-            }));
+            let id = try!(d.read_struct_field("id", 1, TId::decode));
 
             Ok(Node { address: addr, id: id })
         })
@@ -110,13 +207,12 @@ impl serialize::Decodable for Node {
 
 #[cfg(test)]
 mod test {
-    use num::{self, ToPrimitive};
     use rustc_serialize::json;
 
     use super::{GenericAPI, Node};
 
     use super::super::utils::test;
-
+    type TestsIdType = test::IdType;
 
     #[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
     struct SimplifiedNode {
@@ -128,53 +224,53 @@ mod test {
         value: Option<i32>
     }
 
-    impl GenericAPI for DummyAPI {
+    impl GenericAPI<TestsIdType> for DummyAPI {
         type TValue = i32;
-        fn ping<F>(&mut self, node: &Node, callback: F)
-                where F: FnOnce(&Node, bool) {
+        fn ping<F>(&mut self, node: &Node<TestsIdType>, callback: F)
+                where F: FnOnce(&Node<TestsIdType>, bool) {
             callback(node, true);
         }
-        fn find_node<F>(&mut self, id: &num::BigUint, callback: F)
-                where F: FnOnce(Vec<Node>) {
+        fn find_node<F>(&mut self, _id: &TestsIdType, callback: F)
+                where F: FnOnce(Vec<Node<TestsIdType>>) {
             callback(vec![]);
         }
-        fn find_value<F>(&mut self, id: &num::BigUint, callback: F)
-                where F: FnOnce(Option<Self::TValue>, Vec<Node>) {
+        fn find_value<F>(&mut self, _id: &TestsIdType, callback: F)
+                where F: FnOnce(Option<Self::TValue>, Vec<Node<TestsIdType>>) {
             callback(self.value, vec![]);
         }
-        fn store(&mut self, node: &Node, id: &num::BigUint, value: Self::TValue) {
+        fn store(&mut self, _node: &Node<TestsIdType>, _id: &TestsIdType, value: Self::TValue) {
             self.value = Some(value);
         }
     }
 
     #[test]
     fn test_node_encode() {
-        let n = test::new_node(42);
+        let n = test::new_node(test::make_id(42));
         let j = json::encode(&n);
         let m: SimplifiedNode = json::decode(&j.unwrap()).unwrap();
         assert_eq!(test::ADDR, &m.address);
-        assert_eq!("42", &m.id);
+        assert_eq!("2a", &m.id);
     }
 
     #[test]
     fn test_node_decode() {
         let sn = SimplifiedNode {
             address: "127.0.0.1:80".to_string(),
-            id: "42".to_string()
+            id: "2a".to_string()
         };
         let j = json::encode(&sn);
-        let n: Node = json::decode(&j.unwrap()).unwrap();
-        assert_eq!(42, n.id.to_u8().unwrap());
+        let n: Node<TestsIdType> = json::decode(&j.unwrap()).unwrap();
+        assert_eq!(test::make_id(42), n.id);
     }
 
     #[test]
     fn test_node_decode_bad_address() {
         let sn = SimplifiedNode {
             address: "127.0.0.1".to_string(),
-            id: "42".to_string()
+            id: "2a".to_string()
         };
         let j = json::encode(&sn);
-        assert!(json::decode::<Node>(&j.unwrap()).is_err());
+        assert!(json::decode::<Node<TestsIdType>>(&j.unwrap()).is_err());
     }
 
     #[test]
@@ -184,14 +280,14 @@ mod test {
             id: "x42".to_string()
         };
         let j = json::encode(&sn);
-        assert!(json::decode::<Node>(&j.unwrap()).is_err());
+        assert!(json::decode::<Node<TestsIdType>>(&j.unwrap()).is_err());
     }
 
     #[test]
     fn test_node_encode_decode() {
-        let n = test::new_node(42);
+        let n = test::new_node(test::make_id(42));
         let j = json::encode(&n);
-        let n2 = json::decode::<Node>(&j.unwrap()).unwrap();
+        let n2 = json::decode::<Node<TestsIdType>>(&j.unwrap()).unwrap();
         assert_eq!(n.id, n2.id);
         assert_eq!(n.address, n2.address);
     }
@@ -199,8 +295,8 @@ mod test {
     #[test]
     fn test_generic_api() {
         let mut api = DummyAPI { value: None };
-        let n = test::new_node(42);
-        api.ping(&n, |node, res| {
+        let n = test::new_node(test::make_id(42));
+        api.ping(&n, |_node, res| {
             assert!(res);
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,13 @@
 #![crate_name = "dht"]
 #![crate_type = "lib"]
 
+#[cfg(feature="num")]
+extern crate num;
 #[macro_use]
 extern crate log;
 extern crate rand;
 extern crate rustc_serialize;
+extern crate core;
 
 pub use base::GenericId;
 pub use base::GenericNodeTable;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,12 @@
 #![crate_name = "dht"]
 #![crate_type = "lib"]
 
-extern crate num;
 #[macro_use]
 extern crate log;
 extern crate rand;
 extern crate rustc_serialize;
 
+pub use base::GenericId;
 pub use base::GenericNodeTable;
 pub use base::Node;
 pub use knodetable::KNodeTable;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,46 +8,45 @@
 
 //! Generic protocol bits for implementing custom protocols.
 
-use num;
-
-use super::Node;
+use super::{GenericId, Node};
 
 
 /// Payload in the request.
-pub enum RequestPayload<TValue> {
+pub enum RequestPayload<TId, TValue> {
     Ping,
-    FindNode(num::BigUint),
-    FindValue(num::BigUint),
-    Store(num::BigUint, TValue)
+    FindNode(TId),
+    FindValue(TId),
+    Store(TId, TValue)
 }
 
 /// Request structure.
-pub struct Request<TValue> {
-    pub caller: Node,
-    pub request_id: num::BigUint,
-    pub payload: RequestPayload<TValue>
+pub struct Request<TId, TValue> {
+    pub caller: Node<TId>,
+    pub request_id: TId,
+    pub payload: RequestPayload<TId, TValue>
 }
 
 /// Payload in the response.
-pub enum ResponsePayload<TValue> {
-    NodesFound(Vec<Node>),
+pub enum ResponsePayload<TId, TValue> {
+    NodesFound(Vec<Node<TId>>),
     ValueFound(TValue),
     NoResult
 }
 
 /// Response structure.
-pub struct Response<TValue> {
-    pub request: Request<TValue>,
-    pub responder: Node,
-    pub payload: ResponsePayload<TValue>
+pub struct Response<TId, TValue> {
+    pub request: Request<TId, TValue>,
+    pub responder: Node<TId>,
+    pub payload: ResponsePayload<TId, TValue>
 }
 
 /// Trait for a protocol implementation.
 pub trait Protocol : Send {
     /// Value type.
+    type Id: GenericId;
     type Value: Send + Sync;
     /// Parse request from binary data.
-    fn parse_request(&self, data: &[u8]) -> Request<Self::Value>;
+    fn parse_request(&self, data: &[u8]) -> Request<Self::Id, Self::Value>;
     /// Format response to binary data.
-    fn format_response(&self, Response<Self::Value>) -> Vec<u8>;
+    fn format_response(&self, Response<Self::Id, Self::Value>) -> Vec<u8>;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,16 @@ pub mod test {
     pub fn make_id(i: u8) -> IdType {
         vec![i]
     }
+    /*
+    #[cfg(feature="num")]
+    use num;
+    #[cfg(feature="num")]
+    use num::FromPrimitive;
+
+    pub type IdType = num::BigUint;
+    pub fn make_id(i: u8) -> IdType {
+        FromPrimitive::from_usize(i as usize).unwrap()
+    }*/
 
     pub static ADDR: &'static str = "127.0.0.1:8008";
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,29 +5,31 @@
 pub mod test {
     use std::net;
 
-    use num;
-    use num::FromPrimitive;
-
     use super::super::Node;
 
+    /*
+    pub type IdType = u64;
+    pub fn make_id(i: u8) -> IdType {
+        i as IdType
+    }*/
+    pub type IdType = Vec<u8>;
+    pub fn make_id(i: u8) -> IdType {
+        vec![i]
+    }
 
     pub static ADDR: &'static str = "127.0.0.1:8008";
 
-    pub fn new_node(id: usize) -> Node {
+    pub fn new_node(id: IdType) -> Node<IdType> {
         new_node_with_port(id, 8008)
     }
 
-    pub fn new_node_with_port(id: usize, port: u16) -> Node {
+    pub fn new_node_with_port(id: IdType, port: u16) -> Node<IdType> {
         Node {
-            id: FromPrimitive::from_usize(id).unwrap(),
+            id: id,
             address: net::SocketAddr::V4(net::SocketAddrV4::new(
                 net::Ipv4Addr::new(127, 0, 0, 1),
                 port
             ))
         }
-    }
-
-    pub fn usize_to_id(id: usize) -> num::BigUint {
-        FromPrimitive::from_usize(id).unwrap()
     }
 }


### PR DESCRIPTION
As I plan to use this library in a project manipulating addresses as `Vec<u8>` and did not want to spend a lot of time converting between `Vec<u8>` and `num::BigUint`, I rewrote part of this library to work with arbitrary types (provided they implement the `base::GenericId` trait).

This has three consequences:
- Most types now have a `TId` parameter, referring to the type used for storing the ID. Implementations for `u64`, `Vec<u8>`, and `num::BigUint` are provided.
- 'num' is now an optional dependency. If this library is built with `cargo build --features num`, it will depend on 'num', and contain an implementation of the `base::GenericId` trait for `num::BigUint`, which is mostly equivalent to the old behavior.
- ids are now json-serialized to _hexadecimal_ strings instead of _decimal_ strings. The main reason is that it was easier for me to convert `Vec<u8>` to/from hexadecimal than to/from decimal. JSON files are also more geek-readable now (particularily to debug issues with bits).

Also, unfortunately, I could not find how to run tests with the three different supported types without copy-pasting all the tests twice. I can hack something based on `#[cfg]`, but I am open to suggestions.
