### PR TITLE
Use generic addresses TAddr instead of net::SocketAddr.

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -20,33 +20,34 @@ pub enum RequestPayload<TId, TValue> {
 }
 
 /// Request structure.
-pub struct Request<TId, TValue> {
-    pub caller: Node<TId>,
+pub struct Request<TId, TAddr, TValue> {
+    pub caller: Node<TId, TAddr>,
     pub request_id: TId,
     pub payload: RequestPayload<TId, TValue>
 }
 
 /// Payload in the response.
-pub enum ResponsePayload<TId, TValue> {
-    NodesFound(Vec<Node<TId>>),
+pub enum ResponsePayload<TId, TAddr, TValue> {
+    NodesFound(Vec<Node<TId, TAddr>>),
     ValueFound(TValue),
     NoResult
 }
 
 /// Response structure.
-pub struct Response<TId, TValue> {
-    pub request: Request<TId, TValue>,
-    pub responder: Node<TId>,
-    pub payload: ResponsePayload<TId, TValue>
+pub struct Response<TId, TAddr, TValue> {
+    pub request: Request<TId, TAddr, TValue>,
+    pub responder: Node<TId, TAddr>,
+    pub payload: ResponsePayload<TId, TAddr, TValue>
 }
 
 /// Trait for a protocol implementation.
 pub trait Protocol : Send {
     /// Value type.
     type Id: GenericId;
+    type Addr: Send + Sync;
     type Value: Send + Sync;
     /// Parse request from binary data.
-    fn parse_request(&self, data: &[u8]) -> Request<Self::Id, Self::Value>;
+    fn parse_request(&self, data: &[u8]) -> Request<Self::Id, Self::Addr, Self::Value>;
     /// Format response to binary data.
-    fn format_response(&self, Response<Self::Id, Self::Value>) -> Vec<u8>;
+    fn format_response(&self, Response<Self::Id, Self::Addr, Self::Value>) -> Vec<u8>;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,11 +19,11 @@ pub mod test {
 
     pub static ADDR: &'static str = "127.0.0.1:8008";
 
-    pub fn new_node(id: IdType) -> Node<IdType> {
+    pub fn new_node(id: IdType) -> Node<IdType, net::SocketAddr> {
         new_node_with_port(id, 8008)
     }
 
-    pub fn new_node_with_port(id: IdType, port: u16) -> Node<IdType> {
+    pub fn new_node_with_port(id: IdType, port: u16) -> Node<IdType, net::SocketAddr> {
         Node {
             id: id,
             address: net::SocketAddr::V4(net::SocketAddrV4::new(


### PR DESCRIPTION
Implements #4.

Feel free to reject this PR if you think this is too much of a niche feature.