### PR TITLE
lint:  Field Init shorthands

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -211,7 +211,7 @@ where
             let id = d.read_struct_field("id", 1, TId::decode)?;
             Ok(Node {
                 address: addr,
-                id: id,
+                id,
             })
         })
     }

--- a/src/knodetable.rs
+++ b/src/knodetable.rs
@@ -65,8 +65,8 @@ where
         hash_size: usize,
     ) -> KNodeTable<TId, TAddr> {
         KNodeTable {
-            this_id: this_id,
-            hash_size: hash_size,
+            this_id,
+            hash_size,
             buckets: (0..hash_size).map(|_| KBucket::new(bucket_size)).collect(),
         }
     }
@@ -85,11 +85,10 @@ where
         debug_assert!(!diff.is_zero());
         let res = diff.bits() - 1;
         if res >= self.hash_size {
-            panic!(format!(
-                "Distance between IDs {:?} and {:?} is {:?}, which is \
+            panic!("Distance between IDs {:?} and {:?} is {:?}, which is \
                  greater than the hash size ({:?})",
                 id, self.this_id, res, self.hash_size
-            ));
+            );
         }
         debug!(
             "ID {:?} relative to own ID {:?} falls into bucket {:?}",

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -48,5 +48,5 @@ pub trait Protocol: Send {
     /// Parse request from binary data.
     fn parse_request(&self, data: &[u8]) -> Request<Self::Id, Self::Addr, Self::Value>;
     /// Format response to binary data.
-    fn format_response(&self, Response<Self::Id, Self::Addr, Self::Value>) -> Vec<u8>;
+    fn format_response(&self, _: Response<Self::Id, Self::Addr, Self::Value>) -> Vec<u8>;
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -84,10 +84,10 @@ where
             clean_needed: false,
         };
         Service {
-            handler: handler,
-            node_id: node_id,
-            table: table,
-            data: data,
+            handler,
+            node_id,
+            table,
+            data,
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,7 +24,7 @@ pub mod test {
 
     pub fn new_node_with_port(id: IdType, port: u16) -> Node<IdType, net::SocketAddr> {
         Node {
-            id: id,
+            id,
             address: net::SocketAddr::V4(net::SocketAddrV4::new(
                 net::Ipv4Addr::new(127, 0, 0, 1),
                 port,


### PR DESCRIPTION
Use field init shorthands for assignements of structs' fields with the same name

Signed-off-by: dzdidi <deniszalessky@gmail.com>